### PR TITLE
Added fix for kubelet host name issue

### DIFF
--- a/assets/scripts/check-microk8s.sh
+++ b/assets/scripts/check-microk8s.sh
@@ -46,6 +46,42 @@ else
     kubectl config set-cluster microk8s --server=https://127.0.0.1:16443/ --certificate-authority=/var/snap/microk8s/current/certs/ca.crt
     kubectl config set-credentials microk8s-admin --token="$(echo "$PASSWORD" | sudo -S microk8s kubectl config view --raw -o 'jsonpath={.users[0].user.token}')"
     kubectl config set-context microk8s --cluster=microk8s --namespace=default --user=microk8s-admin
+
+    # Update kubelet if hostname is not supported. 
+    # Ref: 'Node is not ready when RBAC is enabled' section of https://microk8s.io/docs/troubleshooting#heading--common-issues
+    HOSTNAME=$(hostname)
+    echo "Hostname is: $HOSTNAME"
+
+    if [[ "$HOSTNAME" =~ [[:upper:]] || "$HOSTNAME" =~ _ ]]; then
+        echo "Hostname is invalid. Uppercase or underscore character found"
+
+        echo "$PASSWORD" | sudo -S chmod a+rwx /var/snap/microk8s/current
+        echo "$PASSWORD" | sudo -S chmod a+rwx /var/snap/microk8s/current/args
+        echo "$PASSWORD" | sudo -S chmod a+rwx /var/snap/microk8s/current/args/kubelet
+
+        ADD_HOSTNAME=false
+        if grep -q "hostname-override" /var/snap/microk8s/current/args/kubelet; then
+            if grep -q "hostname-override=microk8s-node" /var/snap/microk8s/current/args/kubelet; then
+                echo "kubelet hostname-override entry exists"
+            else
+                echo "kubelet hostname-override entry outdated"
+                grep -v 'hostname-override' /var/snap/microk8s/current/args/kubelet >/tmp/kubelet.tmp
+                echo "$PASSWORD" | sudo -S cp /tmp/kubelet.tmp /var/snap/microk8s/current/args/kubelet
+                ADD_HOSTNAME=true
+            fi
+        else
+            ADD_HOSTNAME=true
+        fi
+
+        if $ADD_HOSTNAME; then
+            echo "$PASSWORD" | sudo -S -- sh -c "echo '--hostname-override=microk8s-node' >>/var/snap/microk8s/current/args/kubelet"
+            echo "kubelet hostname-override entry added"
+            sleep 30
+        fi
+
+    else
+        echo "Hostname is valid"
+    fi
 fi
 
 kubectl config use-context microk8s


### PR DESCRIPTION
## Summary

This PR updates kubelet configuration to override hostname when user's hostname contains uppercase of underscore letters. You might have to run `sudo snap remove microk8s --purge` in your terminal before letting control center install microk8s from start and do this hostname fix.


## References

closes #35


## Checklist
- [ ] If this PR is still a WIP, convert to a draft
- [ ] ensure all checks pass
- [ ] When this PR is ready, mark it as "Ready for review"
- [ ] Changes have been manually QA'd
- [ ] Changes reviewed by at least 1 approved reviewer


## QA Steps

_List any additional steps required to QA the changes of this PR, as well as any supplemental images or videos._

